### PR TITLE
Fix typos referencing wrong section of RFC 3548

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Prior to version 1.0, [MIME::Base32](https://metacpan.org/pod/MIME::Base32) used
 decoding methods by default. If you need to maintain that behavior, please call
 `encode_base32hex` or `decode_base32hex` functions directly.
 
-Now, in accordance with [RFC-3548, Section 6](https://tools.ietf.org/html/rfc3548#section-6),
+Now, in accordance with [RFC-3548, Section 5](https://tools.ietf.org/html/rfc3548#section-5),
 [MIME::Base32](https://metacpan.org/pod/MIME::Base32) uses the `encode_base32` and `decode_base32` functions by default.
 
 # FUNCTIONS
@@ -131,4 +131,4 @@ modify it under the same terms as Perl itself.
 
 # SEE ALSO
 
-[MIME::Base64](https://metacpan.org/pod/MIME::Base64), [RFC-3548](https://tools.ietf.org/html/rfc3548#section-6)
+[MIME::Base64](https://metacpan.org/pod/MIME::Base64), [RFC-3548](https://tools.ietf.org/html/rfc3548#section-5)

--- a/lib/MIME/Base32.pm
+++ b/lib/MIME/Base32.pm
@@ -111,7 +111,7 @@ Prior to version 1.0, L<MIME::Base32> used the C<base32hex> (or C<[0-9A-V]>) enc
 decoding methods by default. If you need to maintain that behavior, please call
 C<encode_base32hex> or C<decode_base32hex> functions directly.
 
-Now, in accordance with L<RFC-3548, Section 6|https://tools.ietf.org/html/rfc3548#section-6>,
+Now, in accordance with L<RFC-3548, Section 5|https://tools.ietf.org/html/rfc3548#section-5>,
 L<MIME::Base32> uses the C<encode_base32> and C<decode_base32> functions by default.
 
 =head1 FUNCTIONS
@@ -226,6 +226,6 @@ modify it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 
-L<MIME::Base64>, L<RFC-3548|https://tools.ietf.org/html/rfc3548#section-6>
+L<MIME::Base64>, L<RFC-3548|https://tools.ietf.org/html/rfc3548#section-5>
 
 =cut


### PR DESCRIPTION
In RFC 3548, section 5 describes Base32, not section 6.

In RFC 4648 (which obsoletes RFC 3548), Base32 is described in section 6.

If you'd rather reference the newer RFC, I can close this PR and open another one to change 3548 to 4648.